### PR TITLE
Add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+- package-ecosystem: gradle
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "04:00"
+  open-pull-requests-limit: 15
+  target-branch: main


### PR DESCRIPTION
## Guidelines
This pr adds dependabot to the GitHub repo. It will check every day at 4 AM for new dependency versions and will automatically open prs for them. That helps to keep the app up to date.